### PR TITLE
Minor D optimization

### DIFF
--- a/count_lines_d.d
+++ b/count_lines_d.d
@@ -13,16 +13,25 @@ class Record {
     }
 }
 
-Record create_record(char[][] vals) {
-    auto count = filter!(x => canFind(toLower(x)[1..4], "bc"))(vals).array().length;
-    auto record = new Record(vals[0], count);
+Record create_record(R)(R vals) {
+    /**
+     * auto count = filter!(x => canFind(toLower(x)[1..4], "bc"))(vals).array().length;
+     * optimized:
+     * - removing array() call, which allocates a copy of the data
+     * - replacing filter() with a single call to count()
+     * - only performing toLower() on the part of the string we care about
+     */
+    const count = vals.count!(x => canFind(toLower(x[1..4]), "bc"));
+
+    auto record = new Record(vals.front, count);
     return record;
 }
 
 void main(string[] args) {
     Record[] records;
     foreach (line; stdin.byLine()) {
-        records ~= create_record(split(line, '\t'));
+    	// splitter is a lazy range of `line` split by `\t`
+        records ~= create_record(splitter(line, '\t'));
     }
     writeln(sum(map!(x => x.count)(records)));
 }


### PR DESCRIPTION
In `create_record`:
* Removed call to `array()` which allocates a copy of the range or array
* Replaced `filter()` with `count()`
* Only perform `toLower()` on the part of the string that we care about

In `main`:
* Use lazy range (`splitter`) rather than array (`split`)