### PR TITLE
more idiomatic Nim version

### DIFF
--- a/count_lines_nim.nim
+++ b/count_lines_nim.nim
@@ -6,16 +6,14 @@ type
     count: int
 
 proc createRecord(vals: seq[string]): Record =
-  var record: Record
-  var count = len(filter(vals, proc(x: string): bool = "bc" in toLower(x[1..4])))
-  record = Record(name: vals[0], count: count)
-  return record
+  var count = len(vals.filterIt("bc" in toLower(it[1..3])))
+  result = Record(name: vals[0], count: count)
 
 proc main() =
   var records = newSeq[Record]()
   for line in stdin.lines:
     records.add(createRecord(line.split('\t')))
 
-  echo(sum(map(records, proc(r: Record): int = r.count)))
+  echo sum(records.mapIt(it.count))
 
 main()


### PR DESCRIPTION
* use the implicit `result` for the return
* use `...It` templates (`filterIt`, `mapIt`)
* use method-call syntax for better readability
* fix range (Python's `1:4` is Nim's `1..3` (or `1..<4`))

-----

P.S.

Please specify the exact Nim version you're using. There are lots of differences between Nim 0.19.4 (latest stable) and Nim 0.19.9 (devel version).